### PR TITLE
Refactor percentage change event

### DIFF
--- a/src/zcl_blame_counter.clas.abap
+++ b/src/zcl_blame_counter.clas.abap
@@ -8,15 +8,25 @@ CLASS zcl_blame_counter DEFINITION
   FINAL.
 
   PUBLIC SECTION.
-    "! @parameter i_total_parts | Total number of parts
-    METHODS constructor
-      IMPORTING
-        !i_total_parts TYPE i .
+    "! So that external instances can keep track of the percentage of the object
+    "! which is already loaded.
+    EVENTS percentage_changed
+      EXPORTING
+        VALUE(percentage) TYPE i
+        VALUE(text) TYPE string.
 
-    "! Increment counter and return the new calculated percentage of increments
-    "! that were done against the total of parts (which represents 100%)
+    "! Initialize with total parts
+    "! @parameter i_total_parts | Total number of parts
+    METHODS initialize
+      IMPORTING
+        i_total_parts TYPE i.
+
+    "! Increment counter and raises event with the new calculated percentage of
+    "! increments that were done against the total of parts (which represents 100%).
     METHODS next
-      RETURNING VALUE(r_percentage) TYPE i.
+      IMPORTING
+                i_text TYPE string
+      RAISING   zcx_blame.
   PROTECTED SECTION.
 
   PRIVATE SECTION.
@@ -29,13 +39,19 @@ ENDCLASS.
 CLASS ZCL_BLAME_COUNTER IMPLEMENTATION.
 
 
-  METHOD constructor.
+  METHOD initialize.
     g_total_parts = i_total_parts.
   ENDMETHOD.
 
 
   METHOD next.
+    IF g_total_parts IS INITIAL.
+      RAISE EXCEPTION TYPE zcx_blame.
+    ENDIF.
+
+    DATA percentage TYPE i.
     g_cursor = g_cursor + 1.
-    r_percentage = 100 * g_cursor / g_total_parts.
+    percentage = 100 * g_cursor / g_total_parts.
+    RAISE EVENT percentage_changed EXPORTING percentage = percentage text = i_text.
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_blame_object_clas.clas.abap
+++ b/src/zcl_blame_object_clas.clas.abap
@@ -6,7 +6,6 @@ CLASS zcl_blame_object_clas DEFINITION
   CREATE PUBLIC .
 
   PUBLIC SECTION.
-
     INTERFACES zif_blame_object .
 
     "! Constructor for the class object.
@@ -27,30 +26,31 @@ CLASS zcl_blame_object_clas IMPLEMENTATION.
     g_name = i_name.
   ENDMETHOD.
 
+
   METHOD zif_blame_object~get_part_list.
     DATA(t_method_include) = cl_oo_classname_service=>get_all_method_includes( g_name ).
 
-    DATA(o_counter) = NEW zcl_blame_counter( 9 + lines( t_method_include ) ).
+    io_counter->initialize( 9 + lines( t_method_include ) ).
 
     INSERT NEW #( i_name = 'Class pool'
                   i_vrsd_name = CONV #( g_name )
                   i_vrsd_type = 'CLSD' ) INTO TABLE rt_part.
-    RAISE EVENT zif_blame_object~percentage_complete EXPORTING percentage = o_counter->next( ) text = |Class pool { g_name }|.
+    io_counter->next( |Class pool { g_name }| ).
 
     INSERT NEW #( i_name = 'Public section'
                   i_vrsd_name = CONV #( g_name )
                   i_vrsd_type = 'CPUB' ) INTO TABLE rt_part.
-    RAISE EVENT zif_blame_object~percentage_complete EXPORTING percentage = o_counter->next( ) text = |Public section { g_name }|.
+    io_counter->next( |Public section { g_name }| ).
 
     INSERT NEW #( i_name = 'Protected section'
                   i_vrsd_name = CONV #( g_name )
                   i_vrsd_type = 'CPRO' ) INTO TABLE rt_part.
-    RAISE EVENT zif_blame_object~percentage_complete EXPORTING percentage = o_counter->next( ) text = |Protected section { g_name }|.
+    io_counter->next( |Protected section { g_name }| ).
 
     INSERT NEW #( i_name = 'Private section'
                   i_vrsd_name = CONV #( g_name )
                   i_vrsd_type = 'CPRI' ) INTO TABLE rt_part.
-    RAISE EVENT zif_blame_object~percentage_complete EXPORTING percentage = o_counter->next( ) text = |Private section { g_name }|.
+    io_counter->next( |Private section { g_name }| ).
 
     TRY.
         INSERT NEW #( i_name = 'Local class definition'
@@ -59,7 +59,7 @@ CLASS zcl_blame_object_clas IMPLEMENTATION.
       CATCH zcx_blame.
         ASSERT 1 = 1. " Doesn't exist? Carry on
     ENDTRY.
-    RAISE EVENT zif_blame_object~percentage_complete EXPORTING percentage = o_counter->next( ) text = |Local class definition { g_name }|.
+    io_counter->next( |Local class definition { g_name }| ).
 
     TRY.
         INSERT NEW #( i_name = 'Local class implementation'
@@ -68,7 +68,7 @@ CLASS zcl_blame_object_clas IMPLEMENTATION.
       CATCH zcx_blame.
         ASSERT 1 = 1. " Doesn't exist? Carry on
     ENDTRY.
-    RAISE EVENT zif_blame_object~percentage_complete EXPORTING percentage = o_counter->next( ) text = |Local class implementation { g_name }|.
+    io_counter->next( |Local class implementation { g_name }| ).
 
     TRY.
         INSERT NEW #( i_name = 'Local macros'
@@ -77,7 +77,7 @@ CLASS zcl_blame_object_clas IMPLEMENTATION.
       CATCH zcx_blame.
         ASSERT 1 = 1. " Doesn't exist? Carry on
     ENDTRY.
-    RAISE EVENT zif_blame_object~percentage_complete EXPORTING percentage = o_counter->next( ) text = |Local macros { g_name }|.
+    io_counter->next( |Local macros { g_name }| ).
 
     TRY.
         INSERT NEW #( i_name = 'Local types'
@@ -86,7 +86,7 @@ CLASS zcl_blame_object_clas IMPLEMENTATION.
       CATCH zcx_blame.
         ASSERT 1 = 1. " Doesn't exist? Carry on
     ENDTRY.
-    RAISE EVENT zif_blame_object~percentage_complete EXPORTING percentage = o_counter->next( ) text = |Local types { g_name }|.
+    io_counter->next( |Local types { g_name }| ).
 
     TRY.
         INSERT NEW #( i_name = 'Local test classes'
@@ -95,14 +95,14 @@ CLASS zcl_blame_object_clas IMPLEMENTATION.
       CATCH zcx_blame.
         ASSERT 1 = 1. " Doesn't exist? Carry on
     ENDTRY.
-    RAISE EVENT zif_blame_object~percentage_complete EXPORTING percentage = o_counter->next( ) text = |Local test classes { g_name }|.
+    io_counter->next( |Local test classes { g_name }| ).
 
     LOOP AT cl_oo_classname_service=>get_all_method_includes( g_name ) INTO DATA(s_method_include).
       DATA(method_name) = cl_oo_classname_service=>get_method_by_include( s_method_include-incname )-cpdname.
       INSERT NEW #( i_name = |{ to_lower( method_name ) }()|
                     i_vrsd_name = |{ g_name WIDTH = 30 }{ method_name }|
                     i_vrsd_type = 'METH' ) INTO TABLE rt_part.
-      RAISE EVENT zif_blame_object~percentage_complete EXPORTING percentage = o_counter->next( ) text = |Method { to_lower( method_name ) }()|.
+      io_counter->next( |Method { to_lower( method_name ) }()| ).
     ENDLOOP.
   ENDMETHOD.
 

--- a/src/zcl_blame_object_fugr.clas.abap
+++ b/src/zcl_blame_object_fugr.clas.abap
@@ -102,12 +102,12 @@ CLASS zcl_blame_object_fugr IMPLEMENTATION.
       RAISE EXCEPTION TYPE zcx_blame.
     ENDIF.
 
-    DATA(o_counter) = NEW zcl_blame_counter( 1 + lines( t_include ) ).
+    io_counter->initialize( 1 + lines( t_include ) ).
 
     rt_part = VALUE #( ( NEW #( i_name = |Program { main_program }|
                               i_vrsd_name = CONV #( main_program )
                               i_vrsd_type = 'REPS' ) ) ).
-    RAISE EVENT zif_blame_object~percentage_complete EXPORTING percentage = o_counter->next( ) text = |Program { main_program }|.
+    io_counter->next( |Program { main_program }| ).
 
     DATA(t_function) = get_functions( ).
     LOOP AT t_include INTO DATA(include).
@@ -116,7 +116,7 @@ CLASS zcl_blame_object_fugr IMPLEMENTATION.
                          ( NEW #( i_name = |Include { include }|
                                   i_vrsd_name = CONV #( include )
                                   i_vrsd_type = 'REPS' ) ) ).
-        RAISE EVENT zif_blame_object~percentage_complete EXPORTING percentage = o_counter->next( ) text = |Include { include }|.
+        io_counter->next( |Include { include }| ).
       ENDIF.
     ENDLOOP.
 
@@ -125,7 +125,7 @@ CLASS zcl_blame_object_fugr IMPLEMENTATION.
                          ( NEW #( i_name      = |Function module { os_function->funcname }|
                                 i_vrsd_name = CONV #( os_function->funcname )
                                 i_vrsd_type = 'FUNC' ) ) ).
-      RAISE EVENT zif_blame_object~percentage_complete EXPORTING percentage = o_counter->next( ) text = |Function module { os_function->funcname }|.
+      io_counter->next( |Function module { os_function->funcname }| ).
     ENDLOOP.
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_blame_object_func.clas.abap
+++ b/src/zcl_blame_object_func.clas.abap
@@ -46,10 +46,10 @@ CLASS zcl_blame_object_func IMPLEMENTATION.
 
 
   METHOD zif_blame_object~get_part_list.
-    RAISE EVENT zif_blame_object~percentage_complete EXPORTING percentage = 0 text = CONV #( me->g_name ).
+    io_counter->initialize( 1 ).
     rt_part = VALUE #( ( NEW #( i_name      = CONV #( me->g_name )
                                 i_vrsd_name = CONV #( me->g_name )
                                 i_vrsd_type = 'FUNC' ) ) ).
-    RAISE EVENT zif_blame_object~percentage_complete EXPORTING percentage = 100 text = CONV #( me->g_name ).
+    io_counter->next( CONV #( me->g_name ) ).
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_blame_object_prog.clas.abap
+++ b/src/zcl_blame_object_prog.clas.abap
@@ -29,11 +29,11 @@ CLASS zcl_blame_object_prog IMPLEMENTATION.
 
 
   METHOD zif_blame_object~get_part_list.
-    RAISE EVENT zif_blame_object~percentage_complete EXPORTING percentage = 0 text = CONV #( me->g_name ).
+    io_counter->initialize( 1 ).
     rt_part = VALUE #( ( NEW #( i_name      = CONV #( me->g_name )
                                  i_vrsd_name = CONV #( me->g_name )
                                  i_vrsd_type = 'REPS' ) ) ).
-    RAISE EVENT zif_blame_object~percentage_complete EXPORTING percentage = 100 text = CONV #( me->g_name ).
+    io_counter->next( CONV #( me->g_name ) ).
   ENDMETHOD.
 
 

--- a/src/zcl_blame_parts.clas.abap
+++ b/src/zcl_blame_parts.clas.abap
@@ -6,12 +6,6 @@ CLASS zcl_blame_parts DEFINITION
 
   PUBLIC SECTION.
 
-    "! Event to be raised when percentage complete
-    EVENTS percentage_complete
-      EXPORTING
-        VALUE(percentage) TYPE i
-        VALUE(text) TYPE string.
-
     "! Constructor for an object parts
     "! @parameter i_object_type | Object type
     "! @parameter i_object_name | Object name
@@ -22,7 +16,10 @@ CLASS zcl_blame_parts DEFINITION
 
     "! Load all the data, creating the actual parts
     "! which will load all the versions
+    "! @parameter io_counter | To keep track of progress
     METHODS load
+      IMPORTING
+        io_counter type ref to zcl_blame_counter
       RAISING
         zcx_blame .
 
@@ -58,12 +55,6 @@ CLASS zcl_blame_parts DEFINITION
         !it_part        TYPE zblame_part_t
       RETURNING
         VALUE(rs_stats) TYPE zblame_stats .
-
-    METHODS on_object_percentage_complete
-          FOR EVENT percentage_complete OF zif_blame_object
-      IMPORTING
-          !percentage
-          !text.
 ENDCLASS.
 
 
@@ -167,12 +158,6 @@ CLASS zcl_blame_parts IMPLEMENTATION.
   METHOD load.
     DATA(o_object) = NEW zcl_blame_object_factory( )->get_instance( i_object_type = me->g_type
                                                                     i_object_name = me->g_name ).
-    SET HANDLER me->on_object_percentage_complete FOR o_object.
-    me->gt_part = o_object->get_part_list( ).
-  ENDMETHOD.
-
-
-  METHOD on_object_percentage_complete.
-    RAISE EVENT percentage_complete EXPORTING percentage = percentage text = text.
+    me->gt_part = o_object->get_part_list( io_counter ).
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_blame_run.clas.abap
+++ b/src/zcl_blame_run.clas.abap
@@ -17,8 +17,8 @@ CLASS zcl_blame_run DEFINITION
 
   PROTECTED SECTION.
   PRIVATE SECTION.
-    METHODS on_parts_percentage_complete
-          FOR EVENT percentage_complete OF zcl_blame_parts
+    METHODS on_percentage_changed
+          FOR EVENT percentage_changed OF zcl_blame_counter
       IMPORTING
           !percentage
           !text.
@@ -30,14 +30,15 @@ CLASS zcl_blame_run IMPLEMENTATION.
   METHOD go.
     DATA(o_parts) = NEW zcl_blame_parts( i_object_type = i_object_type
                                          i_object_name = i_object_name ).
-    SET HANDLER me->on_parts_percentage_complete FOR o_parts.
-    o_parts->load( ).
+    data(o_counter) = new zcl_blame_counter( ).
+    SET HANDLER me->on_percentage_changed FOR o_counter.
+    o_parts->load( o_counter ).
     DATA(s_parts) = o_parts->get_data( io_options ).
     NEW zcl_blame_output( io_options->theme )->render( s_parts ).
   ENDMETHOD.
 
 
-  METHOD on_parts_percentage_complete.
+  METHOD on_percentage_changed.
     CALL FUNCTION 'SAPGUI_PROGRESS_INDICATOR'
       EXPORTING
         percentage = percentage

--- a/src/zif_blame_object.intf.abap
+++ b/src/zif_blame_object.intf.abap
@@ -1,15 +1,10 @@
 INTERFACE zif_blame_object
   PUBLIC .
 
-  "! So that external instances can keep track of the percentage of the object
-  "! which is already loaded
-  EVENTS percentage_complete
-    EXPORTING
-      VALUE(percentage) TYPE i
-      VALUE(text) TYPE string.
-
   "! Returns a table of references to part instances
   METHODS get_part_list
+    IMPORTING
+      io_counter type ref to zcl_blame_counter
     RETURNING
       VALUE(rt_part) TYPE zblame_part_ref_t
     RAISING


### PR DESCRIPTION
Avoid event chain by passing the counter object from the outside instead of creating it inside.
Solves #48.